### PR TITLE
Fix news list edit/delete buttons not responding

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -132,8 +132,8 @@
             ref="newsListComponent"
             :canEdit="canEditNews()"
             @create-news="canEditNews() ? openNewsForm() : showPermissionError()"
-            @edit-news="canEditNews() ? openNewsForm : showPermissionError"
-            @delete-news="canEditNews() ? delNews : showPermissionError"
+            @edit-news="canEditNews() ? openNewsForm($event) : showPermissionError()"
+            @delete-news="canEditNews() ? delNews($event) : showPermissionError()"
             @view-news="viewNewsDetail"
           />
 


### PR DESCRIPTION
## Summary
- ensure the news list edit and delete actions are invoked by calling the appropriate handlers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c968f5c1a883238efd4454f3d5193a